### PR TITLE
Fixed incorrect config fetch

### DIFF
--- a/src/EzSitemapBundle/Controller/DefaultController.php
+++ b/src/EzSitemapBundle/Controller/DefaultController.php
@@ -25,7 +25,7 @@ class DefaultController extends Controller {
         $response->headers->set( 'X-Location-Id', 2 );
         $response->headers->set( 'Content-Type', 'application/xml' );
 
-        $rootUrl =  $this->container->getParameter('blend_ez_sitemap.main_uri');
+        $rootUrl =  $this->container->getParameter('blend_ez_sitemap.main_url');
 
         $contentLoaderService = $this->container->get('blend_ez_sitemap.content');
 

--- a/src/EzSitemapBundle/Services/ContentLoader.php
+++ b/src/EzSitemapBundle/Services/ContentLoader.php
@@ -52,6 +52,8 @@ class ContentLoader extends ContainerAware
         $query->sortClauses = [
 //            new SortClause\LocationPathString(Query::SORT_ASC)
         ];
+        
+        $query->limit = 50000;
         $list = $this->searchService->findLocations($query);
 
         $results = [];


### PR DESCRIPTION
This resolves issue with the controller mapping for sitemap.xml throwing `The parameter "blend_ez_sitemap.main_uri" must be defined`

and fixed query limit. the query was limited to [25 by default ezpublish settings](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/API/Repository/Values/Content/Query.php#L87), set the limit to 50000 as per https://www.sitemaps.org/faq.html#faq_sitemap_size